### PR TITLE
Enhancement to retrieve post by slug

### DIFF
--- a/inc/core/shortcodes.php
+++ b/inc/core/shortcodes.php
@@ -1441,14 +1441,21 @@ class Su_Shortcodes {
 				'before'  => '',
 				'after'   => '',
 				'post_id' => '',
+				'slug'    => '',
+				'post_type'=> 'page',
 				'filter'  => ''
 			), $atts, 'post' );
-		// Define current post ID
-		if ( !$atts['post_id'] ) $atts['post_id'] = get_the_ID();
-		// Check post ID
-		if ( !is_numeric( $atts['post_id'] ) || $atts['post_id'] < 1 ) return sprintf( '<p class="su-error">Post: %s</p>', __( 'post ID is incorrect', 'shortcodes-ultimate' ) );
-		// Get the post
-		$post = get_post( $atts['post_id'] );
+		// Get Post ID from slug, if present
+		if ( $atts['slug'] ) {
+		    $post = get_page_by_path( $atts['slug'], OBJECT, $atts['post_type'] );
+		} else {
+			// Define current post ID
+			if ( !$atts['post_id'] ) $atts['post_id'] = get_the_ID();
+			// Check post ID
+			if ( !is_numeric( $atts['post_id'] ) || $atts['post_id'] < 1 ) return sprintf( '<p class="su-error">Post: %s</p>', __( 'post ID is incorrect', 'shortcodes-ultimate' ) );
+			// Get the post
+			$post = get_post( $atts['post_id'] );
+		}
 		// Set default value if meta is empty
 		$post = ( empty( $post ) || empty( $post->$atts['field'] ) ) ? $atts['default'] : $post->$atts['field'];
 		// Apply cutom filter


### PR DESCRIPTION
The 'post' shortcode now accepts attributes "slug" and an optional "post_type" as an alternative to "post_id". This allows reference to a post by name rather than having to know the ID number, making the shortcode more readable. If data is moved into another system, the shortcode won't break even though the ID has changed, eliminating some post-migration hassle. 

If not present the default post_type is "page".

Working examples taken from live code:
- [su_post field="post_content" default="About post or description not found" slug="about"]
- [su_post field="ct_Short_Ad_textarea_a84a" default="Information about Chat Features is not available." slug="chat" post_type="gcc_feature"]

The first shortcode is for the 'about' 'page'. The second shortcode is for a custom post type, a 'gcc_feature', where each post describes a different feature of the site, and 'chat' is one of the feature offered. The field is of course unique to that type. It should seem apparent that referring to the feature called chat is much more intuitive than post ID 441.
